### PR TITLE
Reorganize environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,16 @@
 # This file is a "template" of which env vars need to be defined for your application
 # Copy this file to .env file for development, create environment variables when deploying to production
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
+CH_API_VERSION= # must be set in .env.local
+
 AUTH0_DOMAIN=hicube.auth0.com
-AUTH0_IDENTIFIER=https://api.hicube.caida.org/${CH_API_VERSION}
+AUTH0_IDENTIFIER=https://api.hicube.caida.org # will have /CH_API_VERSION appended
 
+###> symfony/framework-bundle ###
+APP_ENV=dev # should be set in .env.local
+APP_SECRET= # must be set in .env.local
+###< symfony/framework-bundle ###
 
+###> doctrine/doctrine-bundle ###
+DATABASE_URL= # must be set in .env.local
+###< doctrine/doctrine-bundle ###

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -30,4 +30,4 @@ framework:
         #app: cache.adapter.apcu
 
     assets:
-        base_path: '/%env(API_VERSION)%'
+        base_path: '/%env(CH_API_VERSION)%'

--- a/config/packages/jwt_auth.yaml
+++ b/config/packages/jwt_auth.yaml
@@ -1,4 +1,4 @@
 jwt_auth:
   domain: "%env(AUTH0_DOMAIN)%"
   authorized_issuer: "https://%env(AUTH0_DOMAIN)%/"
-  api_identifier: "%env(AUTH0_IDENTIFIER)%"
+  api_identifier: "%env(AUTH0_IDENTIFIER)%/%env(CH_API_VERSION)%"

--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -18,4 +18,4 @@ nelmio_api_doc:
 
     areas: # to filter documented areas
         path_patterns:
-            - ^/%env(API_VERSION)%(?!/docs|/_)/
+            - ^/%env(CH_API_VERSION)%(?!/docs|/_)/

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -4,7 +4,7 @@ security:
             id: App\Security\UserProvider
     firewalls:
         dev:
-            pattern: ^/%env(API_VERSION)%/(_(profiler|wdt)|css|images|js)/
+            pattern: ^/%env(CH_API_VERSION)%/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
             pattern: ^/
@@ -13,5 +13,5 @@ security:
                 authenticator: jwt_auth.jwt_authenticator
 
     access_control:
-        - { path: ^/%env(API_VERSION)%/docs, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/%env(CH_API_VERSION)%/docs, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/, roles: 'ROLE_api:query' }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -53,7 +53,7 @@ class Kernel extends BaseKernel
     protected function configureRoutes(RouteCollectionBuilder $routes)
     {
         $confDir = $this->getProjectDir().'/config';
-        $routePfx = '/'.$_SERVER['API_VERSION'];
+        $routePfx = '/'.$_SERVER['CH_API_VERSION'];
 
         $routes->import($confDir.'/{routes}/*'.self::CONFIG_EXTS, $routePfx, 'glob');
         $routes->import($confDir.'/{routes}/'.$this->environment.'/**/*'.self::CONFIG_EXTS, $routePfx, 'glob');


### PR DESCRIPTION
Also renames the `API_VERSION` variable to `CH_API_VERSION` to avoid confusion with Symfony's `APP_ENV` variable.