### PR TITLE
Fix bug where keycloak URL had to have a trailing slash

### DIFF
--- a/src/Security/KeycloakApiKeyAuthenticator.php
+++ b/src/Security/KeycloakApiKeyAuthenticator.php
@@ -57,7 +57,7 @@ class KeycloakApiKeyAuthenticator extends AbstractGuardAuthenticator
     public function __construct()
     {
         $this->client = new Client();
-        $this->kcserver = $_SERVER["KEYCLOAK_URL"];
+        $this->kcserver = rtrim($_SERVER["KEYCLOAK_URL"], "/");
         $this->kcrealm = $_SERVER["KEYCLOAK_REALM"];
         $this->kcclient = $_SERVER["KEYCLOAK_CLIENT"];
     }
@@ -95,7 +95,7 @@ class KeycloakApiKeyAuthenticator extends AbstractGuardAuthenticator
 
 
         $response = $this->client->request('GET',
-                $this->kcserver . "auth/realms/" . $this->kcrealm . "/check",
+                $this->kcserver . "/auth/realms/" . $this->kcrealm . "/check",
                 $params);
         return new User(null, $response->getBody()->getContents());
     }

--- a/src/Security/KeycloakBearerAuthenticator.php
+++ b/src/Security/KeycloakBearerAuthenticator.php
@@ -60,7 +60,7 @@ class KeycloakBearerAuthenticator extends AbstractGuardAuthenticator
     public function __construct()
     {
         $this->client = new Client();
-        $this->kcserver = $_SERVER["KEYCLOAK_URL"];
+        $this->kcserver = rtrim($_SERVER["KEYCLOAK_URL"], "/");
         $this->kcrealm = $_SERVER["KEYCLOAK_REALM"];
         $this->kcclient = $_SERVER["KEYCLOAK_CLIENT"];
     }
@@ -91,7 +91,7 @@ class KeycloakBearerAuthenticator extends AbstractGuardAuthenticator
         # long valid period (in the order of minutes at most).
 
         $response = $this->client->request('GET',
-                $this->kcserver . "auth/realms/" . $this->kcrealm . "/protocol/openid-connect/userinfo",
+                $this->kcserver . "/auth/realms/" . $this->kcrealm . "/protocol/openid-connect/userinfo",
                 ['headers' => [
                         'Authorization' => $credentials
                         ]


### PR DESCRIPTION
We now provide the slash ourselves, but we also have to be
careful to trim any slashes that the user provides as these
are not ignored by the keycloak server and will cause it to
fail at authenticating.